### PR TITLE
feat: support Markdown deflists

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
         "@cldn/components": "^4.1.1",
         "@tailwindcss/typography": "^0.5.16",
         "markdown-it": "^14.1.0",
-        "markdown-it-anchor": "^9.2.0"
+        "markdown-it-anchor": "^9.2.0",
+        "markdown-it-deflist": "^3.0.0"
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.1.7",
@@ -2239,6 +2240,12 @@
         "@types/markdown-it": "*",
         "markdown-it": "*"
       }
+    },
+    "node_modules/markdown-it-deflist": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-deflist/-/markdown-it-deflist-3.0.0.tgz",
+      "integrity": "sha512-OxPmQ/keJZwbubjiQWOvKLHwpV2wZ5I3Smc81OjhwbfJsjdRrvD5aLTQxmZzzePeO0kbGzAo3Krk4QLgA8PWLg==",
+      "license": "MIT"
     },
     "node_modules/markdown-it/node_modules/entities": {
       "version": "4.5.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@cldn/components": "^4.1.1",
     "@tailwindcss/typography": "^0.5.16",
     "markdown-it": "^14.1.0",
-    "markdown-it-anchor": "^9.2.0"
+    "markdown-it-anchor": "^9.2.0",
+    "markdown-it-deflist": "^3.0.0"
   }
 }

--- a/src/Renderer.ts
+++ b/src/Renderer.ts
@@ -1,6 +1,7 @@
 import {Component, NodeComponent} from "@cldn/components";
 import markdownit from "markdown-it";
 import anchor from "markdown-it-anchor";
+import deflist from "markdown-it-deflist";
 import Lucide from "./lucide";
 
 export default class Renderer {
@@ -39,6 +40,7 @@ export default class Renderer {
                     class: "not-prose hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-blue-600 dark:focus-visible:outline-blue-500 focus-visible:underline",
                 }),
             })
+            .use(deflist)
             .render(markdown);
         this.article.html`${md}`;
 

--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -1,0 +1,5 @@
+declare module "markdown-it-deflist" {
+    import type {PluginSimple} from "markdown-it";
+    const deflist: PluginSimple;
+    export default deflist;
+}


### PR DESCRIPTION
Adds support for definition lists (dl, dt, dd) using the following syntax:

Term
:    Definition

```md
Term
:    Definition
```